### PR TITLE
Task06-Стойко-Н

### DIFF
--- a/project/grammar.py
+++ b/project/grammar.py
@@ -5,9 +5,9 @@ from pyformlang.cfg import Variable
 def cfg_from_file(file_name, start_symbol: str = "S") -> CFG:
     """
     Reading context-free grammar from file
-    @param file_name:
-    @param start_symbol:
-    @return:
+    @param file_name: name of file to read from
+    @param start_symbol: str with start symbol (default 'S')
+    @return: context-free grammar read from file
     """
     with open(file_name, "r") as file:
         text = file.read()

--- a/project/grammar.py
+++ b/project/grammar.py
@@ -1,0 +1,30 @@
+from pyformlang.cfg import CFG
+from pyformlang.cfg import Variable
+
+
+def cfg_from_file(file_name, start_symbol: str = "S") -> CFG:
+    """
+    Reading context-free grammar from file
+    @param file_name:
+    @param start_symbol:
+    @return:
+    """
+    with open(file_name, "r") as file:
+        text = file.read()
+        return CFG.from_text(text, Variable(start_symbol))
+
+
+def cfg_to_weak_cnf(cfg: CFG) -> CFG:
+    """
+    transform CFG to weak CNF
+    @param cfg: input context free grammar
+    @return: weak CNF of input grammar
+    """
+    cfg_eliminated_unit_prods_from = (
+        cfg.eliminate_unit_productions().remove_useless_symbols()
+    )
+    single_term_cfg = (
+        cfg_eliminated_unit_prods_from._get_productions_with_only_single_terminals()
+    )
+    productions = cfg_eliminated_unit_prods_from._decompose_productions(single_term_cfg)
+    return CFG(start_symbol=cfg.start_symbol, productions=set(productions))

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import pytest
 import project  # on import will print something from __init__ file
@@ -15,7 +16,9 @@ def teardown_module(module):
 
 
 def test_1_cfg_from_file_empty():
-    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+    ) as tmp:
         tmp.writelines([])
         cfg = cfg_from_file(tmp.name)
         assert cfg.is_empty()
@@ -24,7 +27,9 @@ def test_1_cfg_from_file_empty():
 
 
 def test_2_cfg_from_file():
-    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+    ) as tmp:
         tmp.write("\n".join(["S -> A | B a", "A -> a", "B -> b"]))
         tmp.flush()
         cfg = cfg_from_file(tmp.name)
@@ -52,7 +57,9 @@ def test_2_cfg_from_file():
 
 
 def test_3_cfg_to_weak_cnf():
-    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+    ) as tmp:
         tmp.write("\n".join(["S -> $ | A | B a", "A -> a | C", "B -> b", "D -> C"]))
         tmp.flush()
         cfg = cfg_from_file(tmp.name)
@@ -70,7 +77,9 @@ def test_3_cfg_to_weak_cnf():
 
 
 def test_4_cfg_to_weak_cnf_with_start():
-    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+    ) as tmp:
         tmp.write(
             "\n".join(
                 ["F -> A | B a | C", "A -> a | C B | $", "B -> b", "D -> C", "C -> b c"]

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -17,89 +17,90 @@ def teardown_module(module):
 
 def test_1_cfg_from_file_empty():
     with tempfile.NamedTemporaryFile(
-        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__)), delete=False
     ) as tmp:
         tmp.writelines([])
-        cfg = cfg_from_file(tmp.name)
-        assert cfg.is_empty()
+        filename = tmp.name
+    cfg = cfg_from_file(filename)
+    assert cfg.is_empty()
 
     print("cfg_from_file_empty test asserted")
 
 
 def test_2_cfg_from_file():
     with tempfile.NamedTemporaryFile(
-        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__)), delete=False
     ) as tmp:
         tmp.write("\n".join(["S -> A | B a", "A -> a", "B -> b"]))
-        tmp.flush()
-        cfg = cfg_from_file(tmp.name)
-        assert not cfg.is_empty()
-        assert len(cfg.productions) == 4
-        assert (
-            pfl_cfg.Production(pfl_cfg.Variable("A"), [pfl_cfg.Terminal("a")])
-            in cfg.productions
+        filename = tmp.name
+    cfg = cfg_from_file(filename)
+    assert not cfg.is_empty()
+    assert len(cfg.productions) == 4
+    assert (
+        pfl_cfg.Production(pfl_cfg.Variable("A"), [pfl_cfg.Terminal("a")])
+        in cfg.productions
+    )
+    assert (
+        pfl_cfg.Production(pfl_cfg.Variable("S"), [pfl_cfg.Variable("A")])
+        in cfg.productions
+    )
+    assert (
+        pfl_cfg.Production(
+            pfl_cfg.Variable("S"), [pfl_cfg.Variable("B"), pfl_cfg.Terminal("a")]
         )
-        assert (
-            pfl_cfg.Production(pfl_cfg.Variable("S"), [pfl_cfg.Variable("A")])
-            in cfg.productions
-        )
-        assert (
-            pfl_cfg.Production(
-                pfl_cfg.Variable("S"), [pfl_cfg.Variable("B"), pfl_cfg.Terminal("a")]
-            )
-            in cfg.productions
-        )
-        assert (
-            pfl_cfg.Production(pfl_cfg.Variable("S"), [pfl_cfg.Terminal("b")])
-            not in cfg.productions
-        )
+        in cfg.productions
+    )
+    assert (
+        pfl_cfg.Production(pfl_cfg.Variable("S"), [pfl_cfg.Terminal("b")])
+        not in cfg.productions
+    )
     print("cfg_from_file test asserted")
 
 
 def test_3_cfg_to_weak_cnf():
     with tempfile.NamedTemporaryFile(
-        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__)), delete=False
     ) as tmp:
         tmp.write("\n".join(["S -> $ | A | B a", "A -> a | C", "B -> b", "D -> C"]))
-        tmp.flush()
-        cfg = cfg_from_file(tmp.name)
-        weak_cnf = cfg_to_weak_cnf(cfg)
-        assert not weak_cnf.is_empty()
-        assert weak_cnf.variables == {
-            pfl_cfg.Variable("S"),
-            pfl_cfg.Variable("B"),
-            pfl_cfg.Variable("a#CNF#"),
-        }
-        assert weak_cnf.contains("")
-        assert weak_cnf.contains("a")
-        assert weak_cnf.contains("ba")
+        filename = tmp.name
+    cfg = cfg_from_file(filename)
+    weak_cnf = cfg_to_weak_cnf(cfg)
+    assert not weak_cnf.is_empty()
+    assert weak_cnf.variables == {
+        pfl_cfg.Variable("S"),
+        pfl_cfg.Variable("B"),
+        pfl_cfg.Variable("a#CNF#"),
+    }
+    assert weak_cnf.contains("")
+    assert weak_cnf.contains("a")
+    assert weak_cnf.contains("ba")
     print("cfg_to_weak_cnf test asserted")
 
 
 def test_4_cfg_to_weak_cnf_with_start():
     with tempfile.NamedTemporaryFile(
-        mode="w", dir=os.path.dirname(os.path.realpath(__file__))
+        mode="w", dir=os.path.dirname(os.path.realpath(__file__)), delete=False
     ) as tmp:
         tmp.write(
             "\n".join(
                 ["F -> A | B a | C", "A -> a | C B | $", "B -> b", "D -> C", "C -> b c"]
             )
         )
-        tmp.flush()
-        cfg = cfg_from_file(tmp.name, "F")
-        weak_cnf = cfg_to_weak_cnf(cfg)
-        assert not weak_cnf.is_empty()
-        assert weak_cnf.variables == {
-            pfl_cfg.Variable("F"),
-            pfl_cfg.Variable("B"),
-            pfl_cfg.Variable("C"),
-            pfl_cfg.Variable("a#CNF#"),
-            pfl_cfg.Variable("b#CNF#"),
-            pfl_cfg.Variable("c#CNF#"),
-        }
-        assert weak_cnf.contains("")
-        assert weak_cnf.contains("a")
-        assert weak_cnf.contains("ba")
-        assert weak_cnf.contains("bc")
-        assert weak_cnf.contains("bcb")
+        filename = tmp.name
+    cfg = cfg_from_file(filename, "F")
+    weak_cnf = cfg_to_weak_cnf(cfg)
+    assert not weak_cnf.is_empty()
+    assert weak_cnf.variables == {
+        pfl_cfg.Variable("F"),
+        pfl_cfg.Variable("B"),
+        pfl_cfg.Variable("C"),
+        pfl_cfg.Variable("a#CNF#"),
+        pfl_cfg.Variable("b#CNF#"),
+        pfl_cfg.Variable("c#CNF#"),
+    }
+    assert weak_cnf.contains("")
+    assert weak_cnf.contains("a")
+    assert weak_cnf.contains("ba")
+    assert weak_cnf.contains("bc")
+    assert weak_cnf.contains("bcb")
     print("cfg_to_weak_cnf_with_start test asserted")

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,0 +1,96 @@
+import tempfile
+import pytest
+import project  # on import will print something from __init__ file
+from project.grammar import cfg_from_file
+from project.grammar import cfg_to_weak_cnf
+import pyformlang.cfg as pfl_cfg
+
+
+def setup_module(module):
+    print("grammar setup module")
+
+
+def teardown_module(module):
+    print("grammar teardown module")
+
+
+def test_1_cfg_from_file_empty():
+    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+        tmp.writelines([])
+        cfg = cfg_from_file(tmp.name)
+        assert cfg.is_empty()
+
+    print("cfg_from_file_empty test asserted")
+
+
+def test_2_cfg_from_file():
+    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+        tmp.write("\n".join(["S -> A | B a", "A -> a", "B -> b"]))
+        tmp.flush()
+        cfg = cfg_from_file(tmp.name)
+        assert not cfg.is_empty()
+        assert len(cfg.productions) == 4
+        assert (
+            pfl_cfg.Production(pfl_cfg.Variable("A"), [pfl_cfg.Terminal("a")])
+            in cfg.productions
+        )
+        assert (
+            pfl_cfg.Production(pfl_cfg.Variable("S"), [pfl_cfg.Variable("A")])
+            in cfg.productions
+        )
+        assert (
+            pfl_cfg.Production(
+                pfl_cfg.Variable("S"), [pfl_cfg.Variable("B"), pfl_cfg.Terminal("a")]
+            )
+            in cfg.productions
+        )
+        assert (
+            pfl_cfg.Production(pfl_cfg.Variable("S"), [pfl_cfg.Terminal("b")])
+            not in cfg.productions
+        )
+    print("cfg_from_file test asserted")
+
+
+def test_3_cfg_to_weak_cnf():
+    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+        tmp.write("\n".join(["S -> $ | A | B a", "A -> a | C", "B -> b", "D -> C"]))
+        tmp.flush()
+        cfg = cfg_from_file(tmp.name)
+        weak_cnf = cfg_to_weak_cnf(cfg)
+        assert not weak_cnf.is_empty()
+        assert weak_cnf.variables == {
+            pfl_cfg.Variable("S"),
+            pfl_cfg.Variable("B"),
+            pfl_cfg.Variable("a#CNF#"),
+        }
+        assert weak_cnf.contains("")
+        assert weak_cnf.contains("a")
+        assert weak_cnf.contains("ba")
+    print("cfg_to_weak_cnf test asserted")
+
+
+def test_4_cfg_to_weak_cnf_with_start():
+    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+        tmp.write(
+            "\n".join(
+                ["F -> A | B a | C", "A -> a | C B | $", "B -> b", "D -> C", "C -> b c"]
+            )
+        )
+        tmp.flush()
+        cfg = cfg_from_file(tmp.name, "F")
+        weak_cnf = cfg_to_weak_cnf(cfg)
+        assert not weak_cnf.is_empty()
+        assert weak_cnf.variables == {
+            pfl_cfg.Variable("F"),
+            pfl_cfg.Variable("B"),
+            pfl_cfg.Variable("C"),
+            pfl_cfg.Variable("a#CNF#"),
+            pfl_cfg.Variable("b#CNF#"),
+            pfl_cfg.Variable("c#CNF#"),
+        }
+        assert weak_cnf.contains("")
+        assert weak_cnf.contains("a")
+        assert weak_cnf.contains("ba")
+        assert weak_cnf.contains("bc")
+        assert weak_cnf.contains("bcb")
+    print("cfg_to_weak_cnf_with_start test asserted")


### PR DESCRIPTION
# Задача 6. Преобразование грамматики в ОНФХ

* **Мягкий дедлайн**: 30.03.2023, 23:59
* **Жёсткий дедлайн**: 03.04.2023, 23:59
* Полный балл: 4

## Определение ОНФХ

Контекстно-свободная грамматика находится в ослабленной нормальной форме Хомского (ОНФХ) тогда и только тогда, когда все её правила имеют следующий вид
1. ```A -> B C```
2. ```A -> a```
3. ```A -> eps```

, где ```A, B, C``` -- произвольные нетерминалы, ```a``` -- произвольный терминал, ```eps```--- обозначение для эпсилон.

Отличия от нормальной формы Хомского (НФХ).
1. Эпсилон может выводиться из любого нетерминала.
2. Стартовый нетерминал может встречаться в правых частях правил.


## Задача

- [x] Используя [возможности pyformlang для работы с контекстно-свободными грамматиками](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html) реализовать **функцию** преобразования контекстно-свободной грамматики в ослабленную нормальную форму Хомского (ОНФХ), но не классическую нормальную форму Хомского (НФХ). НФХ является частным случаем ОНФХ, а значит можно утверждать, что грамматика, находящаяся в НФХ находится и в ОНФХ. Но в данной задаче нас интересует максимально слабая форма, то есть ОНФХ, но не НФХ.
- [x] Предусмотреть возможность чтения грамматики из файла. Формат файла определяется возможностями pyformalng. Например, можно использовать [эту функцию](https://pyformlang.readthedocs.io/en/latest/modules/context_free_grammar.html#pyformlang.cfg.CFG.from_text).
- [x] Добавить необходимые тесты.
